### PR TITLE
Update the Jenkins 2.190 base image as a source of plugin management scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-# TODO: change the base image to an official one
-FROM jenkins4eval/jenkins:2.176.2-jdk8-a2d2c853f8a44895c940827159f6957ba55cb193 as install_scripts_source
-
+FROM jenkins/jenkins:2.190 as install_scripts_source
 FROM cloudbees/cloudbees-jenkins-distribution:2.176.2.3
 COPY --from=install_scripts_source /usr/local/bin/jenkins-support /usr/local/bin/jenkins-support
 COPY --from=install_scripts_source /usr/local/bin/install-plugins.sh /usr/local/bin/install-plugins.sh


### PR DESCRIPTION
After the new release, update the base image.