### PR TITLE
Force all text files to use Unix EOL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Treat all text files without a CR (as we have Docker)
+* text eol=lf


### PR DESCRIPTION
Scripts executed inside the Docker image expect to have Linux line termination.  Git for Windows uses Windows line termination by default.  Since the files *must* have a Linux line ending, let's make it explicit in the .gitattributes file.