### PR TITLE
Hide JENKINS-57326 - don't create bogus jgit

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -391,10 +391,10 @@ tool:
     - home: "git"
       name: "Default"
     # BUG - https://issues.jenkins-ci.org/browse/JENKINS-57326
-    - home: "jgit"
-      name: "jgit"
-    - home: "jgitapache"
-      name: "jgitapache"
+    # - home: "jgit"
+    #   name: "jgit"
+    # - home: "jgitapache"
+    #   name: "jgitapache"
   gradle:
     installations:
     - name: "Gradle-default"


### PR DESCRIPTION
When the git section lists "home" as "jgit", it will create a command line git implementation named "jgit".  That is not what is intended by the demonstration and will mislead users experimenting with the repository. Better to hide the bug for how so that users are not confused when they see a git implementation named "jgit" which does not use JGit.