### PR TITLE
Use "inbound agent" instead of "Java Web Start agent" to avoid confusion

### DIFF
--- a/jenkins.yaml
+++ b/jenkins.yaml
@@ -73,8 +73,11 @@ jenkins:
             disabled: false
             failIfWorkDirIsMissing: false
             internalDir: "remoting"
-      name: "Java Web Start Agent"
-      numExecutors: 1
+            workDirPath: "C:\\J\\AW"
+      name: "Inbound Agent (JNLP)"
+      nodeDescription: "Agent that initiates its own connection to Jenkins"
+      numExecutors: 3
+      remoteFS: "C:\\J\\AA"
       retentionStrategy: "always"
   - permanent:
       launcher:


### PR DESCRIPTION
JNLP and Java Web Start seem to cause confusion because they are often described interchangeably as a way to launch Java programs from a web browser.  In our case, we use `agent.jar` to launch agents from agent computer.